### PR TITLE
Changed overseer url from .org to .dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Request management and media discovery tool for the Plex ecosystem.
 the background and simplifies the downloading verifying and extracting of files
 from [Usenet].
 
-[Overseerr]: https://overseerr.org/
+[Overseerr]: https://overseerr.dev/
 [Usenet]: http://en.wikipedia.org/wiki/Usenet
 
 [:books: Read the full add-on documentation][docs]


### PR DESCRIPTION
# Proposed Changes

The overseer url changed from .org to .dev .
