### PR TITLE
Fix overseerr link and description

### DIFF
--- a/overseerr/.README.j2
+++ b/overseerr/.README.j2
@@ -12,7 +12,8 @@ Request management and media discovery tool for the Plex ecosystem.
 the background and simplifies the downloading verifying and extracting of files
 from [Usenet].
 
-[Overseerr]: https://overseerr.org/
+[Overseerr]: https://overseerr.dev/
+[Overseerr App Repo]: https://github.com/sct/overseerr
 [Usenet]: http://en.wikipedia.org/wiki/Usenet
 
 {% if channel == "edge" %}

--- a/overseerr/.README.j2
+++ b/overseerr/.README.j2
@@ -8,13 +8,13 @@ Request management and media discovery tool for the Plex ecosystem.
 
 ## About
 
-[Overseerr] is a multi-platform binary newsgroup downloader. The program works in
-the background and simplifies the downloading verifying and extracting of files
-from [Usenet].
+[Overseerr] is a request management and media discovery platform for the [Plex] media platform. Overseerr
+integrates into a Plex environment as well as [Radarr]/[Sonarr] for Movie and PVR/TV content management.
 
 [Overseerr]: https://overseerr.dev/
-[Overseerr App Repo]: https://github.com/sct/overseerr
-[Usenet]: http://en.wikipedia.org/wiki/Usenet
+[Plex]: https://plex.tv/
+[Radarr]: https://radarr.video/
+[Sonarr]: https://sonarr.tv/
 
 {% if channel == "edge" %}
 ## WARNING! THIS IS AN EDGE VERSION!


### PR DESCRIPTION
# Proposed Changes

- Link to Overseerr upstream project was incorrect (was [overseerr.org](https://overseerr.org) instead of [overseerr.dev](https://overseerr.dev))
- Revised description explaining the purpose and integration of Overseerr.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised the software description to emphasize Overseerr as a media discovery and request management platform integrated with Plex.
  - Updated and added external links to provide direct access to Overseerr, Plex, Radarr, and Sonarr.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->